### PR TITLE
Add docs directories and file placeholders

### DIFF
--- a/packages/docs/adrs/NNNN-adr-template.md
+++ b/packages/docs/adrs/NNNN-adr-template.md
@@ -1,0 +1,19 @@
+# NNNN) Title
+
+Date: YYYY-MM-DD
+
+## Status
+
+options: proposed, accepted, rejected, deprecated, superseded, ...
+
+## Context
+
+...
+
+## Decision
+
+...
+
+## Consequences
+
+...

--- a/packages/docs/adrs/introduction.md
+++ b/packages/docs/adrs/introduction.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+- intro to ADRs

--- a/packages/docs/adrs/introduction.md
+++ b/packages/docs/adrs/introduction.md
@@ -1,3 +1,9 @@
 # Architecture Decision Records
 
-- intro to ADRs
+An architecture decision record (ADR) aims to document an important software design decision by explaining the context and consequences of the decision.
+
+The ADRs in this repo follow [this template](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md).
+
+For convenience a [template file](./NNNN-adr-template.md) is provided in this folder. When writing a new ADR copy the template and start from there.
+
+If you want to read more about ADRs, please visit https://adr.github.io/

--- a/packages/docs/contributing/contributing-code.md
+++ b/packages/docs/contributing/contributing-code.md
@@ -1,0 +1,4 @@
+# Contributing code
+
+- Task tracking and patch requirements
+- Developer docs

--- a/packages/docs/contributing/designing-components.md
+++ b/packages/docs/contributing/designing-components.md
@@ -1,0 +1,1 @@
+# Designing components

--- a/packages/docs/contributing/guidelines.md
+++ b/packages/docs/contributing/guidelines.md
@@ -1,0 +1,6 @@
+# Contributing guidelines
+
+- introduce that we welcome contributions in many forms
+- how to keep up-to-date
+- task tracking
+- contributing workflows

--- a/packages/docs/design-tokens/introduction.md
+++ b/packages/docs/design-tokens/introduction.md
@@ -1,0 +1,3 @@
+# Design tokens
+
+- What are design tokens?

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -1,0 +1,6 @@
+# About
+
+- What is Codex and what can you do with it
+- link to important docs
+- maintainers
+- guiding principles

--- a/packages/docs/introduction/getting-started.md
+++ b/packages/docs/introduction/getting-started.md
@@ -1,0 +1,13 @@
+# Getting Started
+
+## Components
+
+### Installation
+
+### Using components
+
+### Versioning
+
+### Different builds
+
+## Design tokens


### PR DESCRIPTION
Even thought VitePress isn't set up yet, we can start adding markdown docs. This PR sets up the basic structure and placeholder markdown files for the docs to be written.