### PR TITLE
package.json: Require npm 7.14 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"packages/*"
 	],
 	"engines": {
-		"npm": ">=7",
+		"npm": ">=7.14.0",
 		"node": ">=12"
 	},
 	"scripts": {


### PR DESCRIPTION
Versions before 7.14 don't support the --workspaces and -w flags, which
means trying to run "npm test" results in an infinite loop.