### PR TITLE
Downgrade postcss-custom-properties to 11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 			},
 			"engines": {
 				"node": ">=12",
-				"npm": ">=7"
+				"npm": ">=7.14.0"
 			}
 		},
 		"node_modules/@algolia/cache-browser-local-storage": {
@@ -5167,21 +5167,6 @@
 				"url": "https://opencollective.com/postcss/"
 			}
 		},
-		"node_modules/postcss-custom-properties": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.0.0.tgz",
-			"integrity": "sha512-eAyX3rMjZKxdne6tWKjkWbNWfw6bbv4xTsrjNJ7C3uGDODrzbQXR+ueshRkw7Lhlhc3qyTmYH/sFfD0AbhgdSQ==",
-			"dev": true,
-			"dependencies": {
-				"postcss-values-parser": "^6"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"postcss": "^8.3"
-			}
-		},
 		"node_modules/postcss-nested": {
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
@@ -5337,23 +5322,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 			"dev": true
-		},
-		"node_modules/postcss-values-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.0.tgz",
-			"integrity": "sha512-EpjCoM7Ccso7Pn4NY8pcdMyjMULgepDPCgM80xx5M3Kdlb+cd6Pym+Q2ywvqc5ix+CF6/ltdt7XspkVFUkXm3w==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "^1.1.4",
-				"is-url-superb": "^4.0.0",
-				"quote-unquote": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"peerDependencies": {
-				"postcss": "^8.2.9"
-			}
 		},
 		"node_modules/preact": {
 			"version": "10.5.14",
@@ -5606,12 +5574,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/quote-unquote": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
-			"integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=",
-			"dev": true
 		},
 		"node_modules/ramda": {
 			"version": "0.27.1",
@@ -6864,7 +6826,7 @@
 				"autoprefixer": "^10.3.7",
 				"design-tokens": "*",
 				"postcss": "^8.3.9",
-				"postcss-custom-properties": "^12.0.0",
+				"postcss-custom-properties": "^11.0.0",
 				"postcss-nested": "^5.0.6",
 				"postcss-remove-root": "^0.0.2",
 				"typescript": "^4.4.3",
@@ -6872,6 +6834,52 @@
 			},
 			"peerDependencies": {
 				"vue": "^3.2.19"
+			}
+		},
+		"packages/vue-components/node_modules/postcss-custom-properties": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz",
+			"integrity": "sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-values-parser": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"packages/vue-components/node_modules/postcss-values-parser": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
+			"integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "^1.1.4",
+				"is-url-superb": "^4.0.0",
+				"postcss": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"packages/vue-components/node_modules/postcss-values-parser/node_modules/postcss": {
+			"version": "7.0.39",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+			"dev": true,
+			"dependencies": {
+				"picocolors": "^0.2.1",
+				"source-map": "^0.6.1"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
 			}
 		}
 	},
@@ -10771,15 +10779,6 @@
 				"source-map-js": "^0.6.2"
 			}
 		},
-		"postcss-custom-properties": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.0.0.tgz",
-			"integrity": "sha512-eAyX3rMjZKxdne6tWKjkWbNWfw6bbv4xTsrjNJ7C3uGDODrzbQXR+ueshRkw7Lhlhc3qyTmYH/sFfD0AbhgdSQ==",
-			"dev": true,
-			"requires": {
-				"postcss-values-parser": "^6"
-			}
-		},
 		"postcss-nested": {
 			"version": "5.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
@@ -10896,17 +10895,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
 			"integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
 			"dev": true
-		},
-		"postcss-values-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.0.tgz",
-			"integrity": "sha512-EpjCoM7Ccso7Pn4NY8pcdMyjMULgepDPCgM80xx5M3Kdlb+cd6Pym+Q2ywvqc5ix+CF6/ltdt7XspkVFUkXm3w==",
-			"dev": true,
-			"requires": {
-				"color-name": "^1.1.4",
-				"is-url-superb": "^4.0.0",
-				"quote-unquote": "^1.0.0"
-			}
 		},
 		"preact": {
 			"version": "10.5.14",
@@ -11117,12 +11105,6 @@
 		"queue-microtask": {
 			"version": "1.2.3",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true
-		},
-		"quote-unquote": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
-			"integrity": "sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=",
 			"dev": true
 		},
 		"ramda": {
@@ -11807,11 +11789,45 @@
 				"autoprefixer": "^10.3.7",
 				"design-tokens": "*",
 				"postcss": "^8.3.9",
-				"postcss-custom-properties": "^12.0.0",
+				"postcss-custom-properties": "^11.0.0",
 				"postcss-nested": "^5.0.6",
 				"postcss-remove-root": "^0.0.2",
 				"typescript": "^4.4.3",
 				"vite": "^2.6.5"
+			},
+			"dependencies": {
+				"postcss-custom-properties": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-11.0.0.tgz",
+					"integrity": "sha512-Fhnx/QLt+CTt23A/KKVx1anZD9nmVpOxKCKv5owWacMoOsBXFhMAD6SZYbmPMH4nHdIeMUnWOvLZnlY4niS0sA==",
+					"dev": true,
+					"requires": {
+						"postcss-values-parser": "^4.0.0"
+					}
+				},
+				"postcss-values-parser": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-4.0.0.tgz",
+					"integrity": "sha512-R9x2D87FcbhwXUmoCXJR85M1BLII5suXRuXibGYyBJ7lVDEpRIdKZh4+8q5S+/+A4m0IoG1U5tFw39asyhX/Hw==",
+					"dev": true,
+					"requires": {
+						"color-name": "^1.1.4",
+						"is-url-superb": "^4.0.0",
+						"postcss": "^7.0.5"
+					},
+					"dependencies": {
+						"postcss": {
+							"version": "7.0.39",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
+							"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
+							"dev": true,
+							"requires": {
+								"picocolors": "^0.2.1",
+								"source-map": "^0.6.1"
+							}
+						}
+					}
+				}
 			}
 		},
 		"vue-docgen-api": {

--- a/packages/vue-components/package.json
+++ b/packages/vue-components/package.json
@@ -18,7 +18,7 @@
 		"autoprefixer": "^10.3.7",
 		"design-tokens": "*",
 		"postcss": "^8.3.9",
-		"postcss-custom-properties": "^12.0.0",
+		"postcss-custom-properties": "^11.0.0",
 		"postcss-nested": "^5.0.6",
 		"postcss-remove-root": "^0.0.2",
 		"typescript": "^4.4.3",


### PR DESCRIPTION
Variable substitution wasn't working at all in 12.0.0, see also
https://github.com/postcss/postcss-custom-properties/issues/256